### PR TITLE
Show markdown details of issues and file name in annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ build:
     - mvn -V --color always -ntp clean verify -Dmaven.test.failure.ignore=true -Ppit
 
 test:
-  image: uhafner/autograding-gitlab-action:1.8.0
+  image: uhafner/autograding-gitlab-action:1.9.0
   stage: test
   variables: 
     # You need to provide a GitLab access token as CI/CD Variable GITLAB_TOKEN in the GitLab user interface 

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -41,7 +41,7 @@ rectangle "coverage-model\n\n0.37.0" as edu_hm_hafner_coverage_model_jar
 rectangle "jackson-databind\n\n2.16.1" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.16.1" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.16.1" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n1.8.0" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n1.9.0" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-api\n\n5.5.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n1.2.2" as jakarta_activation_jakarta_activation_api_jar
 rectangle "jersey-common\n\n2.39.1" as org_glassfish_jersey_core_jersey_common_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
   <packaging>jar</packaging>
 
   <scm>
@@ -32,7 +32,7 @@
     <jib-maven-plugin.version>3.4.1</jib-maven-plugin.version>
     <testcontainers.version>1.19.7</testcontainers.version>
 
-    <autograding-model.version>3.25.0</autograding-model.version>
+    <autograding-model.version>3.26.0</autograding-model.version>
   </properties>
 
   <dependencies>
@@ -96,7 +96,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
+          </argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -117,20 +118,14 @@
             <goals>
               <goal>build</goal>
             </goals>
-            <configuration>
-              <to>
-                <image>docker.io/uhafner/autograding-gitlab-action:${docker-image-tag}</image>
-                <auth>
-                  <username>${env.DOCKER_IO_USERNAME}</username>
-                  <password>${env.DOCKER_IO_PASSWORD}</password>
-                </auth>
-              </to>
-            </configuration>
           </execution>
         </executions>
         <configuration>
           <to>
-            <image>docker.io/uhafner/autograding-gitlab-action:${docker-image-tag}</image>
+            <image>docker.io/uhafner/autograding-gitlab-action</image>
+            <tags>
+              <tag>${docker-image-tag}</tag>
+            </tags>
             <auth>
               <username>${env.DOCKER_IO_USERNAME}</username>
               <password>${env.DOCKER_IO_PASSWORD}</password>

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
@@ -141,7 +141,7 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
         gitLabApi.getCommitsApi().addComment(project.getId(), sha, comment);
     }
 
-    private String getEnv(final String key, final FilteredLog log) {
+    static String getEnv(final String key, final FilteredLog log) {
         String value = StringUtils.defaultString(System.getenv(key));
         log.logInfo(">>>> " + key + ": " + value);
         return value;

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
@@ -28,11 +28,14 @@ class GitLabCommitCommentBuilder extends CommentBuilder {
 
     @Override
     @SuppressWarnings("checkstyle:ParameterNumber")
-    protected void createComment(final CommentType commentType, final String relativePath, final int lineStart, final int lineEnd,
+    protected void createComment(final CommentType commentType, final String relativePath,
+            final int lineStart, final int lineEnd,
             final String message, final String title,
-            final int columnStart, final int columnEnd, final String details) {
+            final int columnStart, final int columnEnd,
+            final String details, final String markDownDetails) {
         try {
-            var markdownMessage = GitLabDiffCommentBuilder.createMarkdownMessage(commentType, title, message, details);
+            var markdownMessage = GitLabDiffCommentBuilder.createMarkdownMessage(commentType, relativePath,
+                    lineStart, lineEnd, columnStart, columnEnd, title, message, markDownDetails);
             commitsApi.addComment(projectId, sha, markdownMessage, relativePath, lineStart, LineType.NEW);
         }
         catch (GitLabApiException exception) {

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -197,7 +197,7 @@ public class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:1.8.0"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:1.9.0"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container) throws TimeoutException {

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
@@ -1,0 +1,154 @@
+package edu.hm.hafner.grading.gitlab;
+
+import org.gitlab4j.api.DiscussionsApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.MergeRequestVersion;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.grading.AggregatedScore;
+import edu.hm.hafner.util.FilteredLog;
+
+import static edu.hm.hafner.grading.gitlab.GitLabDiffCommentBuilder.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GitLabDiffCommentBuilderTest {
+    private static final String FILE_NAME = "src/main/java/File.java";
+    private static final String URL = "https://gitlab.lrz.de/dev/java2-assignment1";
+    private static final String SHA = "58c1e8a980dc0beb7d92d2266eb3e58852720a76";
+    private static final String FILE = "src/main/java/edu/hm/hafner/java2/assignment1/Assignment.java";
+
+    private static final String ANALYSIS_CONFIGURATION = """
+            {
+              "analysis": [
+                {
+                  "name": "Style",
+                  "id": "style",
+                  "tools": [
+                    {
+                      "id": "checkstyle",
+                      "name": "Checkstyle",
+                      "pattern": "checkstyle.xml"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    @Test
+    void shouldCreateRange() {
+        assertThat(createRange('L', 0, 0)).isEmpty();
+        assertThat(createRange('L', -1, 10)).isEmpty();
+
+        assertThat(createRange('L', 1, 10)).isEqualTo("L1-L10");
+        assertThat(createRange('L', 1, 1)).isEqualTo("L1");
+    }
+
+    @Test
+    void shouldCreateLinesAndColumns() {
+        assertThat(createLinesAndColumns("L1", 0, 0)).isEqualTo("(L1)");
+        assertThat(createLinesAndColumns("L1", 1, 0)).isEqualTo("(L1:C1)");
+        assertThat(createLinesAndColumns("L1", 2, 3)).isEqualTo("(L1:C2-C3)");
+    }
+
+    @Test
+    void shouldCreateMarkDownMessage() {
+        assertThat(createMarkdownMessage(
+                CommentType.WARNING, FILE,
+                10, 20, 5, 8,
+                "Title", "Message", "Details", this::getEnv))
+                .contains("#### :warning: &nbsp; Title", "Message", "Details",
+                        "[Assignment.java(L10-L20:C5-C8)]",
+                        URL + "/blob/" + SHA + "/" + FILE + "#L10-L20");
+        assertThat(createMarkdownMessage(
+                CommentType.WARNING, FILE,
+                10, 20, 0, 8,
+                "Title", "Message", "Details", this::getEnv))
+                .contains("#### :warning: &nbsp; Title", "Message", "Details",
+                        "[Assignment.java(L10-L20)]",
+                        URL + "/blob/" + SHA + "/" + FILE + "#L10-L20");
+        assertThat(createMarkdownMessage(
+                CommentType.WARNING, FILE,
+                10, 10, 0, 8,
+                "Title", "Message", "Details", this::getEnv))
+                .contains("#### :warning: &nbsp; Title", "Message", "Details",
+                        "[Assignment.java(L10)]",
+                        URL + "/blob/" + SHA + "/" + FILE + "#L10");
+    }
+
+    private String getEnv(final String environment) {
+        if ("CI_PROJECT_URL".equals(environment)) {
+            return URL;
+        }
+        if ("CI_COMMIT_SHA".equals(environment)) {
+            return SHA;
+        }
+        throw new IllegalArgumentException("Unknown environment: " + environment);
+    }
+
+    @Test
+    void shouldCreateComment() throws GitLabApiException {
+        var discussions = mock(DiscussionsApi.class);
+        var builder = new GitLabDiffCommentBuilder(discussions, mock(MergeRequest.class), mock(
+                MergeRequestVersion.class), "/work");
+
+        builder.createComment(CommentType.WARNING, FILE_NAME, 10, 100,
+                "Message", "Title", 1, 10, "Details", "Details-Markdown");
+
+        var details = ArgumentCaptor.forClass(String.class);
+        verify(discussions).createMergeRequestDiscussion(anyLong(), anyLong(), details.capture(), isNull(), isNull(),
+                any());
+
+        assertThat(details.getValue()).contains(
+                "#### :warning: &nbsp; Title",
+                "[File.java(L10-L100:C1-C10)](/blob//src/main/java/File.java#L10-L100)",
+                "Message",
+                "Details");
+    }
+
+    @Test
+    void shouldCreateAnnotation() throws GitLabApiException {
+        var discussions = mock(DiscussionsApi.class);
+        var gitlab = new GitLabDiffCommentBuilder(discussions, mock(MergeRequest.class), mock(
+                MergeRequestVersion.class), "/work");
+
+        var score = new AggregatedScore(ANALYSIS_CONFIGURATION, new FilteredLog("Tests"));
+        score.gradeAnalysis((tool, log) -> createReport());
+
+        gitlab.createAnnotations(score);
+
+        var details = ArgumentCaptor.forClass(String.class);
+        verify(discussions).createMergeRequestDiscussion(anyLong(), anyLong(), details.capture(), isNull(), isNull(),
+                any());
+
+        assertThat(details.getValue()).contains(
+                "#### :warning: &nbsp; CheckStyle: HiddenField",
+                        "[File.java(L10-L100:C1-C10)](/blob//src/main/java/File.java#L10-L100): Message",
+                        "<p>Since Checkstyle 3.0</p><p>",
+                        "Checks that a local variable or a parameter does not shadow a field",
+                        "that is defined in the same class.");
+    }
+
+    private Report createReport() {
+        var report = new Report();
+        try (var builder = new IssueBuilder()) {
+            report.add(builder.setFileName(FILE_NAME)
+                    .setLineStart(10)
+                    .setLineEnd(100)
+                    .setOrigin("checkstyle")
+                    .setOriginName("CheckStyle")
+                    .setMessage("Message")
+                    .setCategory("Title")
+                    .setType("HiddenField")
+                    .setColumnStart(1)
+                    .setColumnEnd(10)
+                    .build());
+        }
+        return report;
+    }
+}


### PR DESCRIPTION
Shows issue details (if available) and affected file (and line number) in the source code annotation comments.

Fixes https://github.com/uhafner/autograding-gitlab-action/issues/27

Screenshot:

![Bildschirmfoto 2024-03-23 um 22 53 54](https://github.com/uhafner/autograding-gitlab-action/assets/503338/b87003d9-3414-4210-bb2c-94714e6b7122)
