### PR TITLE
Refactor creation of line comments

### DIFF
--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -58,12 +58,12 @@ jobs:
                   {
                     "id": "checkstyle",
                     "name": "CheckStyle",
-                    "pattern": "**/target/checkstyle-result.xml"
+                    "pattern": "**/target/**checkstyle-result.xml"
                   },
                   {
                     "id": "pmd",
                     "name": "PMD",
-                    "pattern": "**/target/pmd.xml"
+                    "pattern": "**/target/**pmd.xml"
                   },
                   {
                     "id": "error-prone",

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -58,12 +58,12 @@ jobs:
                   {
                     "id": "checkstyle",
                     "name": "CheckStyle",
-                    "pattern": "**/target/**checkstyle-result.xml"
+                    "pattern": "**/target/checkstyle-*/checkstyle-result.xml"
                   },
                   {
                     "id": "pmd",
                     "name": "PMD",
-                    "pattern": "**/target/**pmd.xml"
+                    "pattern": "**/target/pmd-*/pmd.xml"
                   },
                   {
                     "id": "error-prone",

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,29 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>8.0.2</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -93,29 +93,6 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <groupId>io.github.git-commit-id</groupId>
-        <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>8.0.2</version>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-          <includeOnlyProperties>
-            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
-            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
-          </includeOnlyProperties>
-          <commitIdGenerationMode>full</commitIdGenerationMode>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>edu.hm.hafner</groupId>
     <artifactId>codingstyle-pom</artifactId>
-    <version>4.0.1</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
 

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
@@ -5,6 +5,7 @@ import org.gitlab4j.api.Constants.LineType;
 import org.gitlab4j.api.GitLabApiException;
 
 import edu.hm.hafner.grading.CommentBuilder;
+import edu.hm.hafner.util.FilteredLog;
 
 /**
  * Creates GitLab commit comments for static analysis warnings, for lines with missing coverage, and for lines with
@@ -16,14 +17,16 @@ class GitLabCommitCommentBuilder extends CommentBuilder {
     private final CommitsApi commitsApi;
     private final Long projectId;
     private final String sha;
+    private final FilteredLog log;
 
     GitLabCommitCommentBuilder(final CommitsApi commitsApi, final long projectId, final String sha,
-            final String workingDirectory) {
+            final String workingDirectory, final FilteredLog log) {
         super(workingDirectory);
 
         this.commitsApi = commitsApi;
         this.projectId = projectId;
         this.sha = sha;
+        this.log = log;
     }
 
     @Override
@@ -34,12 +37,13 @@ class GitLabCommitCommentBuilder extends CommentBuilder {
             final int columnStart, final int columnEnd,
             final String details, final String markDownDetails) {
         try {
-            var markdownMessage = GitLabDiffCommentBuilder.createMarkdownMessage(commentType, relativePath,
-                    lineStart, lineEnd, columnStart, columnEnd, title, message, markDownDetails);
+            var markdownMessage = GitLabDiffCommentBuilder.createMarkdownMessage(commentType, relativePath, lineStart,
+                    lineEnd, columnStart, columnEnd, title, message, markDownDetails, GitLabDiffCommentBuilder::getEnv);
+
             commitsApi.addComment(projectId, sha, markdownMessage, relativePath, lineStart, LineType.NEW);
         }
         catch (GitLabApiException exception) {
-            // ignore exceptions
+            log.logException(exception, "Can't create commit comment for %s", relativePath);
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -4,6 +4,8 @@ import java.util.function.Function;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.gitlab4j.api.CommitsApi;
+import org.gitlab4j.api.Constants.LineType;
 import org.gitlab4j.api.DiscussionsApi;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.MergeRequest;
@@ -11,25 +13,30 @@ import org.gitlab4j.api.models.MergeRequestVersion;
 import org.gitlab4j.api.models.Position;
 
 import edu.hm.hafner.grading.CommentBuilder;
+import edu.hm.hafner.util.FilteredLog;
 
 /**
- * Creates GitLab commit comments for static analysis warnings, for lines with missing coverage, and for lines with
- * survived mutations.
+ * Creates GitLab merge request comments for static analysis warnings, for lines with missing coverage, and for lines with
+ * survived mutations. If the comment cannot be created on the merge request, then a comment is created on the commit.
  *
  * @author Ullrich Hafner
  */
 class GitLabDiffCommentBuilder extends CommentBuilder {
+    private final CommitsApi commitsApi;
     private final DiscussionsApi discussionsApi;
     private final MergeRequest mergeRequest;
     private final MergeRequestVersion lastVersion;
+    private final FilteredLog log;
 
-    GitLabDiffCommentBuilder(final DiscussionsApi discussionsApi, final MergeRequest mergeRequest,
-            final MergeRequestVersion lastVersion, final String workingDirectory) {
+    GitLabDiffCommentBuilder(final CommitsApi commitsApi, final DiscussionsApi discussionsApi, final MergeRequest mergeRequest,
+            final MergeRequestVersion lastVersion, final String workingDirectory, final FilteredLog log) {
         super(workingDirectory);
 
+        this.commitsApi = commitsApi;
         this.discussionsApi = discussionsApi;
         this.mergeRequest = mergeRequest;
         this.lastVersion = lastVersion;
+        this.log = log;
     }
 
     @Override
@@ -39,32 +46,32 @@ class GitLabDiffCommentBuilder extends CommentBuilder {
             final String message, final String title,
             final int columnStart, final int columnEnd,
             final String details, final String markDownDetails) {
+        var sha = lastVersion.getHeadCommitSha();
+        var position = new Position()
+                .withBaseSha(lastVersion.getBaseCommitSha())
+                .withHeadSha(sha)
+                .withStartSha(lastVersion.getStartCommitSha())
+                .withNewLine(lineStart)
+                .withNewPath(relativePath)
+                .withPositionType(Position.PositionType.TEXT);
+        var markdownMessage = createMarkdownMessage(commentType, relativePath, lineStart, lineEnd, columnStart,
+                columnEnd, title, message, markDownDetails, GitLabDiffCommentBuilder::getEnv);
         try {
-            var position = new Position()
-                    .withBaseSha(lastVersion.getBaseCommitSha())
-                    .withHeadSha(lastVersion.getHeadCommitSha())
-                    .withStartSha(lastVersion.getStartCommitSha())
-                    .withNewLine(lineStart)
-                    .withOldPath(relativePath)
-                    .withNewPath(relativePath)
-                    .withPositionType(Position.PositionType.TEXT);
-            var markdownMessage = createMarkdownMessage(commentType, relativePath,
-                    lineStart, lineEnd, columnStart, columnEnd,
-                    title, message, markDownDetails);
-            discussionsApi.createMergeRequestDiscussion(mergeRequest.getProjectId(), mergeRequest.getIid(),
+            discussionsApi.createMergeRequestDiscussion(
+                    mergeRequest.getProjectId(),
+                    mergeRequest.getIid(),
                     markdownMessage, null, null, position);
         }
-        catch (GitLabApiException exception) {
-            // ignore exceptions and continue
-        }
-    }
+        catch (GitLabApiException exception) { // If the comment is on a file or position not part of the diff
+            log.logException(exception, "Can't create merge request comment for %s in #%d", relativePath, mergeRequest.getIid());
 
-    @SuppressWarnings("checkstyle:ParameterNumber")
-    static String createMarkdownMessage(final CommentType commentType, final String relativePath,
-            final int lineStart, final int lineEnd, final int columnStart, final int columnEnd,
-            final String title, final String message, final String details) {
-        return createMarkdownMessage(commentType, relativePath, lineStart, lineEnd, columnStart, columnEnd, title,
-                message, details, GitLabDiffCommentBuilder::getEnv);
+            try {
+                commitsApi.addComment(mergeRequest.getProjectId(), sha, markdownMessage, relativePath, lineStart, LineType.NEW);
+            }
+            catch (GitLabApiException ignored) {
+                log.logException(exception, "Can't create commit comment for %s", relativePath);
+            }
+        }
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -84,7 +91,8 @@ class GitLabDiffCommentBuilder extends CommentBuilder {
         }
         var link = "[%s](%s)".formatted(linkName, linkUrl);
 
-        return String.format("#### :%s: &nbsp; %s%n%n%s: %s", getIcon(commentType), title, link, message)
+        return String.format("%s%n%n#### :%s: &nbsp; %s%n%n%s: %s",
+                GitLabAutoGradingRunner.AUTOGRADING_MARKER, getIcon(commentType), title, link, message)
                 + (details.isBlank() ? StringUtils.EMPTY : "\n\n" + details);
     }
 

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
@@ -40,6 +40,8 @@ class GitLabDiffCommentBuilderTest {
               ]
             }
             """;
+    private static final String PROJECT_URL = "CI_PROJECT_URL";
+    private static final String COMMIT_SHA = "CI_COMMIT_SHA";
 
     @Test
     void shouldCreateRange() {
@@ -83,10 +85,10 @@ class GitLabDiffCommentBuilderTest {
     }
 
     private String getEnv(final String environment) {
-        if ("CI_PROJECT_URL".equals(environment)) {
+        if (PROJECT_URL.equals(environment)) {
             return URL;
         }
-        if ("CI_COMMIT_SHA".equals(environment)) {
+        if (COMMIT_SHA.equals(environment)) {
             return SHA;
         }
         throw new IllegalArgumentException("Unknown environment: " + environment);

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading.gitlab;
 
+import org.gitlab4j.api.CommitsApi;
 import org.gitlab4j.api.DiscussionsApi;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.MergeRequest;
@@ -94,8 +95,9 @@ class GitLabDiffCommentBuilderTest {
     @Test
     void shouldCreateComment() throws GitLabApiException {
         var discussions = mock(DiscussionsApi.class);
-        var builder = new GitLabDiffCommentBuilder(discussions, mock(MergeRequest.class), mock(
-                MergeRequestVersion.class), "/work");
+        var commits = mock(CommitsApi.class);
+        var builder = new GitLabDiffCommentBuilder(commits, discussions, mock(MergeRequest.class),
+                mock(MergeRequestVersion.class), "/work", new FilteredLog("GitLab"));
 
         builder.createComment(CommentType.WARNING, FILE_NAME, 10, 100,
                 "Message", "Title", 1, 10, "Details", "Details-Markdown");
@@ -114,8 +116,9 @@ class GitLabDiffCommentBuilderTest {
     @Test
     void shouldCreateAnnotation() throws GitLabApiException {
         var discussions = mock(DiscussionsApi.class);
-        var gitlab = new GitLabDiffCommentBuilder(discussions, mock(MergeRequest.class), mock(
-                MergeRequestVersion.class), "/work");
+        var commits = mock(CommitsApi.class);
+        var gitlab = new GitLabDiffCommentBuilder(commits, discussions, mock(MergeRequest.class), mock(
+                        MergeRequestVersion.class), "/work", new FilteredLog("GitLab"));
 
         var score = new AggregatedScore(ANALYSIS_CONFIGURATION, new FilteredLog("Tests"));
         score.gradeAnalysis((tool, log) -> createReport());


### PR DESCRIPTION
Existing comments are now deleted from merge requests before new comments will be added. Additionally, line comments are now placed before the summary so that the summary will be always visible when there are too many line comments. 

When GitLab fails to show a comment for a diff then the comment will be written again as a commit note.

Will close #28 