### PR TITLE
Add line comments for missed coverage in pit results

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -41,7 +41,7 @@ rectangle "coverage-model\n\n0.37.0" as edu_hm_hafner_coverage_model_jar
 rectangle "jackson-databind\n\n2.16.1" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.16.1" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.16.1" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n1.11.0-SNAPSHOT" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n1.11.0" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-api\n\n5.5.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n1.2.2" as jakarta_activation_jakarta_activation_api_jar
 rectangle "jersey-common\n\n2.39.1" as org_glassfish_jersey_core_jersey_common_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>1.11.0-SNAPSHOT</version>
+  <version>1.11.0</version>
   <packaging>jar</packaging>
 
   <scm>
@@ -32,7 +32,7 @@
     <jib-maven-plugin.version>3.4.1</jib-maven-plugin.version>
     <testcontainers.version>1.19.7</testcontainers.version>
 
-    <autograding-model.version>3.26.0</autograding-model.version>
+    <autograding-model.version>3.27.0</autograding-model.version>
   </properties>
 
   <dependencies>

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -197,7 +197,7 @@ public class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:1.11.0-SNAPSHOT"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:1.11.0"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container) throws TimeoutException {
@@ -206,7 +206,7 @@ public class GitLabAutoGradingRunnerDockerITest {
 
         var composedConsumer = toStringConsumer.andThen(waitingConsumer);
         container.followOutput(composedConsumer);
-        waitingConsumer.waitUntil(frame -> frame.getUtf8String().contains("End Autograding"), 60, TimeUnit.SECONDS);
+        waitingConsumer.waitUntil(frame -> frame.getUtf8String().contains("End GitLab Autograding"), 60, TimeUnit.SECONDS);
 
         return toStringConsumer.toUtf8String();
     }


### PR DESCRIPTION
It makes sense to also report missing code lines during reporting of mutation coverage results as PIT do not use the integration tests while evaluating the mutations.