### PR TITLE
Add new options to autograder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 workflow:
   name: CI
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 image:
   name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/maven:3.9.6-eclipse-temurin-21-alpine
@@ -58,6 +60,7 @@ autograding:
   variables:
     MAX_WARNING_COMMENTS: 10
     MAX_COVERAGE_COMMENTS: 10
+    SKIP_COMMIT_COMMENTS: true
     CONFIG: |
       {
         "tests": {

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ This action can be configured using the following environment variables (see exa
 - ``GITLAB_TOKEN``: mandatory GitLab access token, see next section for details.
 - ``CONFIG: "{...}"``: optional configuration, see next sections for details, or consult the [autograding-model](https://github.com/uhafner/autograding-model) project for the exact implementation. If not specified, a [default configuration](https://github.com/uhafner/autograding-model/blob/main/src/main/resources/default-config.json) will be used.
 - ``DISPLAY_NAME: "Name in the comment title"``: optional name in the comment title (overwrites the default: "Autograding score").
-- ``SKIP_LINE_COMMENTS: true``: Optional flag to skip the creation of commit comments at specific lines (for warnings and missed coverage). By default, line comments are created.
+- ``SKIP_LINE_COMMENTS: true``: Optional flag to skip the creation of commit comments at specific lines (for warnings and missed coverage). By default, line comments are created. Alternatively, you can limit the number of comments by setting the following parameters.
 - ``MAX_WARNING_COMMENTS: <number>``: Optional parameter to limit the number of warning comments at specific lines. By default, all line comments are created.
 - ``MAX_COVERAGE_COMMENTS: <number>``: Optional parameter to limit the number of coverage comments at specific lines. By default, all line comments are created.
 - ``SKIP_DETAILS: true``: Optional flag to skip the details of the results (e.g., stack trace of failed tests, autograding detail tables) in the commit or merge request comment. By default, the detailed report is created.
+- ``SKIP_WARNING_DESCRIPTION: true``: Optional flag to skip the adding of warning descriptions for static analysis warnings. By default, the descriptions are added. Since static analysis tools like CheckStyle or SpotBugs have lengthy descriptions, it makes sense to skip the descriptions if you have many warnings.
+- ``SKIP_COMMIT_COMMENTS: true``: Optional flag to skip the creation of comments in commits. When this option is enabled, then comments are only added to merge requests. By default, comments are created for commits and merge requests. When all your changes are integrated in merge requests, then you can skip the commit comments to reduce the noise in the merge request: in this case, the comments in the merge request will be replaced with the results of the latest commit only.
 
 ## GitLab Access Token
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>1.13.0-SNAPSHOT</version>
+  <version>1.99.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <scm>
@@ -32,7 +32,7 @@
     <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
     <testcontainers.version>1.20.1</testcontainers.version>
 
-    <autograding-model.version>3.32.0</autograding-model.version>
+    <autograding-model.version>3.34.0</autograding-model.version>
   </properties>
 
   <dependencies>
@@ -133,7 +133,7 @@
             </auth>
           </to>
           <from>
-            <image>maven:3.9.6-eclipse-temurin-21-alpine</image>
+            <image>maven:3.9.9-eclipse-temurin-21-alpine</image>
           </from>
         </configuration>
       </plugin>

--- a/src/main/java/edu/hm/hafner/grading/gitlab/Environment.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/Environment.java
@@ -1,0 +1,61 @@
+package edu.hm.hafner.grading.gitlab;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+/**
+ * Simple utility to access environment variables.
+ *
+ * @author Ullrich Hafner
+ */
+class Environment {
+    private final FilteredLog log;
+
+    Environment(final FilteredLog log) {
+        this.log = log;
+    }
+
+    int getInteger(final String key) {
+        var value = StringUtils.defaultString(read(key));
+        try {
+            var integer = Integer.parseInt(value);
+            log.logInfo(">>>> %s: %s", key, integer);
+            return integer;
+        }
+        catch (NumberFormatException exception) {
+            if (StringUtils.isBlank(value)) {
+                log.logInfo(">>>> %s: not set", key);
+            }
+            else {
+                log.logError(">>>> Error: no valid integer value in environment variable key %s: %s", key, value);
+            }
+
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    String getString(final String key) {
+        String value = read(key);
+        if (StringUtils.isBlank(value)) {
+            log.logInfo(">>>> %s: not set", key);
+        }
+        else {
+            log.logInfo(">>>> %s: %s", key, value);
+        }
+        return StringUtils.defaultString(value);
+    }
+
+    boolean getBoolean(final String name) {
+        var value = StringUtils.defaultString(read(name));
+        var defined = StringUtils.isNotBlank(value) && !StringUtils.equalsIgnoreCase(value, "false");
+        log.logInfo(">>>> %s: %b", name, defined);
+        return defined;
+    }
+
+    @CheckForNull
+    private String read(final String key) {
+        return System.getenv(key);
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
@@ -31,14 +31,16 @@ class GitLabCommitCommentBuilder extends GitLabCommentBuilder {
             final String message, final String title,
             final int columnStart, final int columnEnd,
             final String details, final String markDownDetails) {
-        try {
-            var markdownMessage = createMarkdownMessage(commentType, relativePath, lineStart,
-                    lineEnd, columnStart, columnEnd, title, message, markDownDetails, this::getEnv);
+        if (showCommentsInCommit()) {
+            try {
+                var markdownMessage = createMarkdownMessage(commentType, relativePath, lineStart,
+                        lineEnd, columnStart, columnEnd, title, message, markDownDetails, this::getEnv);
 
-            getCommitsApi().addComment(projectId, sha, markdownMessage, relativePath, lineStart, LineType.NEW);
-        }
-        catch (GitLabApiException exception) {
-            getLog().logException(exception, "Can't create commit comment for %s", relativePath);
+                getCommitsApi().addComment(projectId, sha, markdownMessage, relativePath, lineStart, LineType.NEW);
+            }
+            catch (GitLabApiException exception) {
+                getLog().logException(exception, "Can't create commit comment for %s", relativePath);
+            }
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -56,11 +56,14 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
         catch (GitLabApiException exception) { // If the comment is on a file or position not part of the diff
             getLog().logException(exception, "Can't create merge request comment for %s in #%d", relativePath, mergeRequest.getIid());
 
-            try {
-                getCommitsApi().addComment(mergeRequest.getProjectId(), sha, markdownMessage, relativePath, lineStart, LineType.NEW);
-            }
-            catch (GitLabApiException ignored) {
-                getLog().logException(exception, "Can't create commit comment for %s", relativePath);
+            if (showCommentsInCommit()) {
+                try {
+                    getCommitsApi().addComment(mergeRequest.getProjectId(), sha, markdownMessage, relativePath,
+                            lineStart, LineType.NEW);
+                }
+                catch (GitLabApiException ignored) {
+                    getLog().logException(exception, "Can't create commit comment for %s", relativePath);
+                }
             }
         }
     }


### PR DESCRIPTION
Now we can hide commit notes so that we only get notes on merge requests. Additionally, we can skip descriptions for warnings.

Will fix #50 (at least partly) .