### PR TITLE
Bump version of autograding-model to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <docker-image-tag>${project.version}</docker-image-tag>
     <docker-image-baseline>v3-SNAPSHOT</docker-image-baseline>
 
-    <autograding-model.version>5.6.0</autograding-model.version>
+    <autograding-model.version>6.0.0</autograding-model.version>
     <gitlab4j-api.version>5.8.0</gitlab4j-api.version>
     <testcontainers.version>1.20.6</testcontainers.version>
 


### PR DESCRIPTION
Use latest version of autograding the fixes rendering of tables.