### PR TITLE
Bump version of autograding plugin to 6.3.0

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -41,7 +41,7 @@ rectangle "coverage-model\n\n0.37.0" as edu_hm_hafner_coverage_model_jar
 rectangle "jackson-databind\n\n2.16.1" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.16.1" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.16.1" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n3.3.0-SNAPSHOT" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n3.3.0" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-api\n\n5.5.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n1.2.2" as jakarta_activation_jakarta_activation_api_jar
 rectangle "jersey-common\n\n2.39.1" as org_glassfish_jersey_core_jersey_common_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>jar</packaging>
 
   <name>Autograding GitLab Action</name>
@@ -34,9 +34,9 @@
   <properties>
     <module.name>${project.groupId}.autograding.gitlab.action</module.name>
     <docker-image-tag>${project.version}</docker-image-tag>
-    <docker-image-baseline>v3-SNAPSHOT</docker-image-baseline>
+    <docker-image-baseline>v3</docker-image-baseline>
 
-    <autograding-model.version>6.2.0</autograding-model.version>
+    <autograding-model.version>6.3.0</autograding-model.version>
     <gitlab4j-api.version>5.8.0</gitlab4j-api.version>
     <testcontainers.version>1.20.6</testcontainers.version>
 

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -195,7 +195,7 @@ public class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:3.3.0-SNAPSHOT"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:3.3.0"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container) throws TimeoutException {


### PR DESCRIPTION
This update contains a better table view for tests.