### PR TITLE
Do not set a position if the whole file is marked

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -42,9 +42,11 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
                 .withBaseSha(lastVersion.getBaseCommitSha())
                 .withHeadSha(sha)
                 .withStartSha(lastVersion.getStartCommitSha())
-                .withNewLine(lineStart)
                 .withNewPath(relativePath)
                 .withPositionType(Position.PositionType.TEXT);
+        if (lineStart > 0) {
+            position.withNewLine(lineStart);
+        }
         var markdownMessage = createMarkdownMessage(commentType, relativePath, lineStart, lineEnd, columnStart,
                 columnEnd, title, message, markDownDetails, this::getEnv);
         try {
@@ -67,4 +69,5 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
             }
         }
     }
+
 }


### PR DESCRIPTION
GitLab will throw an Exception if the annotation line is set to zero (whole file). 

Closes #103