### PR TITLE
Always print errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <configuration>
           <mainClass>edu.hm.hafner.grading.gitlab.ResultCrawler</mainClass>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <docker-image-tag>${project.version}</docker-image-tag>
     <docker-image-baseline>v4</docker-image-baseline>
 
-    <autograding-model.version>8.4.0</autograding-model.version>
+    <autograding-model.version>8.5.0</autograding-model.version>
     <gitlab4j-api.version>6.1.0</gitlab4j-api.version>
     <testcontainers.version>1.21.3</testcontainers.version>
 

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
@@ -15,7 +15,6 @@ import edu.hm.hafner.grading.AggregatedScore;
 import edu.hm.hafner.grading.AutoGradingRunner;
 import edu.hm.hafner.grading.GradingReport;
 import edu.hm.hafner.grading.QualityGateResult;
-import edu.hm.hafner.grading.QualityGateResult.OverallStatus;
 import edu.hm.hafner.util.FilteredLog;
 
 import java.util.Collection;
@@ -89,13 +88,8 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
     }
 
     @Override
-    protected void handleQualityGateResult(final QualityGateResult qualityGateResult, final FilteredLog log) {
-        if (log.hasErrors()) {
-            throw new IllegalStateException("Autograding finished with errors, failing the action");
-        }
-        if (qualityGateResult.getOverallStatus() != OverallStatus.SUCCESS) {
-            throw new IllegalStateException("Quality gate failed, failing the action");
-        }
+    protected boolean failOnQualityGate() {
+        return true;
     }
 
     private void grade(final AggregatedScore score, final QualityGateResult qualityGateResult, final GitLabApi gitLabApi, final Project project, final String sha,

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -199,7 +199,7 @@ public class GitLabAutoGradingRunnerDockerITest {
                             "Quality gates evaluation completed: ❌ FAILURE",
                             "Passed: 0, Failed: 1",
                             "❌ Line Coverage: 11.00 >= 100.00",
-                            "java.lang.IllegalStateException: Autograding finished with errors, failing the action");
+                            "Quality gates failed, failing the action");
         }
     }
 
@@ -229,7 +229,7 @@ public class GitLabAutoGradingRunnerDockerITest {
                             "Autograding score - 351 of 500 (70%)")
                     .contains("Environment variable 'QUALITY_GATES' not found or empty",
                             "No quality gates to evaluate",
-                            "Autograding finished with errors, failing the action");
+                            "Autograding finished with some errors in the log, failing the action");
         }
     }
 


### PR DESCRIPTION
In GitLab there is no status to show that the action failed. There we need to fail the whole action.
