### PR TITLE
Replace the Docker.io registry with the LRZ GitLab container registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,15 +151,15 @@
             <mainClass>edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner</mainClass>
           </container>
           <to>
-            <image>docker.io/uhafner/autograding-gitlab-action</image>
+            <image>gitlab.lrz.de:5005/dev/docker-registry/autograding</image>
             <tags>
               <tag>${docker-image-tag}</tag>
               <tag>v${docker-image-tag}</tag>
               <tag>${docker-image-baseline}</tag>
             </tags>
             <auth>
-              <username>${env.DOCKER_IO_USERNAME}</username>
-              <password>${env.DOCKER_IO_PASSWORD}</password>
+              <username>no-required</username>
+              <password>${env.GITLAB_TOKEN}</password>
             </auth>
           </to>
           <from>


### PR DESCRIPTION
In order to tests a SNAPSHOT version it makes more sense to use the LRZ GitLab container registry when pushing the docker images.