### PR TITLE
Enable architecture tests

### DIFF
--- a/.github/quality-monitor-pr.json
+++ b/.github/quality-monitor-pr.json
@@ -12,6 +12,12 @@
         "icon": "rocket",
         "name": "Integration Tests",
         "pattern": "**/target/failsafe-reports/TEST*.xml"
+      },
+      {
+        "id": "junit",
+        "icon": "no_entry",
+        "name": "Architecture Tests",
+        "pattern": "**/target/archunit-reports/TEST*.xml"
       }
     ]
   },

--- a/.github/quality-monitor.json
+++ b/.github/quality-monitor.json
@@ -12,6 +12,12 @@
         "icon": "rocket",
         "name": "Integration Tests",
         "pattern": "**/target/failsafe-reports/TEST*.xml"
+      },
+      {
+        "id": "junit",
+        "icon": "no_entry",
+        "name": "Architecture Tests",
+        "pattern": "**/target/archunit-reports/TEST*.xml"
       }
     ]
   },

--- a/src/test/java/edu/hm/hafner/grading/archunit/ArchitectureTest.java
+++ b/src/test/java/edu/hm/hafner/grading/archunit/ArchitectureTest.java
@@ -1,0 +1,46 @@
+package edu.hm.hafner.grading.archunit;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import edu.hm.hafner.archunit.ArchitectureRules;
+
+/**
+ * Defines several architecture rules for the code coverage model.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+@AnalyzeClasses(packages = "edu.hm.hafner.grading")
+final class ArchitectureTest {
+    @ArchTest
+    static final ArchRule NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR = ArchitectureRules.NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR;
+
+    @ArchTest
+    static final ArchRule NO_PUBLIC_TEST_CLASSES = ArchitectureRules.NO_PUBLIC_TEST_CLASSES;
+
+    @ArchTest
+    static final ArchRule ONLY_PACKAGE_PRIVATE_TEST_METHODS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_TEST_METHODS;
+
+    @ArchTest
+    static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS.allowEmptyShould(true);
+
+    @ArchTest
+    static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_PACKAGE_ACCESSED = ArchitectureRules.NO_FORBIDDEN_PACKAGE_ACCESSED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_ANNOTATION_USED = ArchitectureRules.NO_FORBIDDEN_ANNOTATION_USED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
+
+    @ArchTest
+    static final ArchRule READ_RESOLVE_SHOULD_BE_PROTECTED = ArchitectureRules.READ_RESOLVE_SHOULD_BE_PROTECTED;
+
+    private ArchitectureTest() {
+    }
+}

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.*;
  *
  * @author Ullrich Hafner
  */
-public class GitLabAutoGradingRunnerDockerITest {
+class GitLabAutoGradingRunnerDockerITest {
     private static final String CONFIGURATION = """
             {
               "tests": {


### PR DESCRIPTION
Some simple checks to verify that we use the correct Java API.