### PR TITLE
Deploy image to Docker Hub and GitHub Container Registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build and deploy to Docker hub
+    name: Build and deploy to Docker Hub and GHCR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,8 +22,18 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.12
-      - name: Build and deploy
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and deploy to Docker Hub
         env:
           DOCKER_IO_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
           DOCKER_IO_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
         run: mvn -ntp clean install -Pci
+      - name: Build and deploy to GHCR
+        run: | 
+          mvn -ntp clean compile jib:build \
+            -Djib.to.image=ghcr.io/${{ github.repository_owner }}/autograding-gitlab-action


### PR DESCRIPTION
Adds GitHub Container Registry (GHCR) as an additional registry. The action now pushes to both Docker Hub and GHCR, and uses the GHCR image by default to avoid rate limit issues.

