### PR TITLE
Fix guard that checks the merge request ID

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
@@ -282,7 +282,7 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
         var projectId = env.getString("CI_PROJECT_ID");
         var mergeRequest = env.getString("CI_MERGE_REQUEST_IID");
 
-        if (gitlabUrl.isBlank() || oAuthToken.isBlank() || projectId.isBlank() || !mergeRequest.isBlank()) {
+        if (gitlabUrl.isBlank() || oAuthToken.isBlank() || projectId.isBlank() || mergeRequest.isBlank()) {
             return Map.of();
         }
 


### PR DESCRIPTION
When there is no MR we need to skip the delta.