### PR TITLE
Add logging of position when an exception occurs

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -47,7 +47,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n2.19.2" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.19.2" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.19.2" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n5.1.0" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n5.1.1" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-models\n\n6.1.0" as org_gitlab4j_gitlab4j_models_jar
 rectangle "gitlab4j-api\n\n6.1.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n2.1.1" as jakarta_activation_jakarta_activation_api_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>5.1.0</version>
+  <version>5.1.1</version>
   <packaging>jar</packaging>
 
   <name>Autograding GitLab Action</name>

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -55,6 +55,7 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
         }
         catch (GitLabApiException exception) { // If the comment is on a file or position not part of the diff
             getLog().logException(exception, "Can't create merge request comment for %s in #%d", relativePath, mergeRequest.getIid());
+            getLog().logError("Position is %s", position);
 
             if (showCommentsInCommit()) {
                 try {

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -259,7 +259,7 @@ class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.1.0"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.1.1"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)


### PR DESCRIPTION
Provide more details for exceptions of the style:

```
Can't create merge request comment for edu/hm/hafner/java2/assignment1/Assignment.java in #2
org.gitlab4j.api.GitLabApiException: 400 Bad request - Note {:line_code=>["can't be blank", "must be a valid line code"]}
	at org.gitlab4j.api.AbstractApi.validate(AbstractApi.java:784)
	at org.gitlab4j.api.AbstractApi.post(AbstractApi.java:383)
	at org.gitlab4j.api.DiscussionsApi.createMergeRequestDiscussion(DiscussionsApi.java:452)
	at edu.hm.hafner.grading.gitlab.GitLabDiffCommentBuilder.createComment(GitLabDiffCommentBuilder.java:51)
	at edu.hm.hafner.grading.CommentBuilder.createCoverageComment(CommentBuilder.java:144)
	at edu.hm.hafner.grading.CommentBuilder.createCoverageComment(CommentBuilder.java:130)
	at edu.hm.hafner.grading.CommentBuilder.createAnnotationForMissedLineRange(CommentBuilder.java:236)
	at edu.hm.hafner.grading.CommentBuilder.lambda$createAnnotationsForMissedLines$1(CommentBuilder.java:229)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at edu.hm.hafner.grading.CommentBuilder.createAnnotationsForMissedLines(CommentBuilder.java:229)
	at edu.hm.hafner.grading.CommentBuilder.lambda$createAnnotationsForMissedLines$0(CommentBuilder.java:224)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at edu.hm.hafner.grading.CommentBuilder.createAnnotationsForMissedLines(CommentBuilder.java:224)
	at edu.hm.hafner.grading.CommentBuilder.createAnnotations(CommentBuilder.java:91)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.createLineCommentsOnDiff(GitLabAutoGradingRunner.java:200)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.commentMergeRequest(GitLabAutoGradingRunner.java:152)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.grade(GitLabAutoGradingRunner.java:129)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.publishGradingResult(GitLabAutoGradingRunner.java:97)
	at edu.hm.hafner.grading.AutoGradingRunner.run(AutoGradingRunner.java:135)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.main(GitLabAutoGradingRunner.java:52)
```