### PR TITLE
Make LOG_COMMENTS a boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Since static analysis tools like CheckStyle or SpotBugs have lengthy description
 - ``SKIP_COMMIT_COMMENTS`` (boolean, default: `false`): Optional flag to skip the creation of comments in commits. 
 When this option is enabled, then comments are only added to merge requests. 
 When all your changes are integrated in merge requests, then you can skip the commit comments to reduce the noise in the merge request: in this case, the comments in the merge request will be replaced with the results of the latest commit only.
+- ``LOG_COMMENTS`` (boolean, default: `false`): Optional flag to log the created comments in the GitLab diffs. 
+This can be useful for debugging purposes when GitLab API calls fail, and you want to check which comments were created and which were not. 
 
 ## GitLab Access Token
 

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -47,7 +47,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n2.19.2" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.19.2" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.19.2" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n5.2.0" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n5.2.1" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-models\n\n6.1.0" as org_gitlab4j_gitlab4j_models_jar
 rectangle "gitlab4j-api\n\n6.1.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n2.1.1" as jakarta_activation_jakarta_activation_api_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>5.2.0</version>
+  <version>5.2.1</version>
   <packaging>jar</packaging>
 
   <name>Autograding GitLab Action</name>

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -1,6 +1,5 @@
 package edu.hm.hafner.grading.gitlab;
 
-import org.apache.commons.lang3.StringUtils;
 import org.gitlab4j.api.CommitsApi;
 import org.gitlab4j.api.DiscussionsApi;
 import org.gitlab4j.api.GitLabApiException;
@@ -30,7 +29,7 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
         this.discussionsApi = discussionsApi;
         this.mergeRequest = mergeRequest;
         this.lastVersion = lastVersion;
-        isLoggingEnabled = StringUtils.isNotBlank(new Environment(log).getString("LOG_COMMENTS"));
+        isLoggingEnabled = new Environment(log).getBoolean("LOG_COMMENTS");
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -259,7 +259,7 @@ class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.2.0"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.2.1"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)


### PR DESCRIPTION
Optional flag to log the created comments in the GitLab diffs.  This can be useful for debugging purposes when GitLab API calls fail, and you want to check which comments were created and which were not. 


