### PR TITLE
Skip comments that are not part of the diff

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -47,7 +47,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n2.19.2" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.19.2" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.19.2" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "autograding-gitlab-action\n\n5.2.1" as edu_hm_hafner_autograding_gitlab_action_jar
+rectangle "autograding-gitlab-action\n\n5.3.0" as edu_hm_hafner_autograding_gitlab_action_jar
 rectangle "gitlab4j-models\n\n6.1.0" as org_gitlab4j_gitlab4j_models_jar
 rectangle "gitlab4j-api\n\n6.1.0" as org_gitlab4j_gitlab4j_api_jar
 rectangle "jakarta.activation-api\n\n2.1.1" as jakarta_activation_jakarta_activation_api_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-gitlab-action</artifactId>
-  <version>5.2.1</version>
+  <version>5.3.0</version>
   <packaging>jar</packaging>
 
   <name>Autograding GitLab Action</name>
@@ -38,7 +38,7 @@
 
     <java.version>25</java.version>
 
-    <autograding-model.version>15.0.0</autograding-model.version>
+    <autograding-model.version>16.0.0</autograding-model.version>
     <gitlab4j-api.version>6.2.0</gitlab4j-api.version>
     <testcontainers.version>2.0.3</testcontainers.version>
 

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunner.java
@@ -197,8 +197,8 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
             final MergeRequest mergeRequest, final MergeRequestVersion lastVersion,
             final AggregatedScore score, final Environment env, final FilteredLog log) {
         if (canCreateLineComments(env)) {
-            var annotationBuilder = new GitLabDiffCommentBuilder(commitsApi, discussionsApi, mergeRequest, lastVersion,
-                    getWorkingDirectory(env), log);
+            var annotationBuilder = new GitLabDiffCommentBuilder(commitsApi, getModifiedFilesAndLines(),
+                    discussionsApi, mergeRequest, lastVersion, getWorkingDirectory(env), log);
             annotationBuilder.createAnnotations(score);
         }
         else {
@@ -209,8 +209,8 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
     private void createLineCommentsOnCommit(final GitLabApi gitLabApi, final Project project, final String sha,
             final AggregatedScore score, final Environment env, final FilteredLog log) {
         if (canCreateLineComments(env)) {
-            var commentBuilder = new GitLabCommitCommentBuilder(gitLabApi.getCommitsApi(), project.getId(), sha,
-                    getWorkingDirectory(env), log);
+            var commentBuilder = new GitLabCommitCommentBuilder(gitLabApi.getCommitsApi(), getModifiedFilesAndLines(),
+                    project.getId(), sha, getWorkingDirectory(env), log);
             commentBuilder.createAnnotations(score);
         }
         else {
@@ -277,7 +277,7 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
     }
 
     @Override
-    protected Map<String, Set<Integer>> getModifiedLines(final FilteredLog log) {
+    protected Map<String, Set<Integer>> extractModifiedLinesFromDiff(final FilteredLog log) {
         var env = new Environment(log);
         var gitlabUrl = env.getString("CI_SERVER_URL");
         var oAuthToken = env.getString("GITLAB_TOKEN");
@@ -312,7 +312,7 @@ public class GitLabAutoGradingRunner extends AutoGradingRunner {
     }
 
     @Override
-    protected Optional<Path> obtainDeltaReports(final FilteredLog log) {
+    protected Optional<Path> fetchDeltaReportsFromPreviousPipeline(final FilteredLog log) {
         var env = new Environment(log);
         var gitlabUrl = env.getString("CI_SERVER_URL");
         var oAuthToken = env.getString("GITLAB_TOKEN");

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommentBuilder.java
@@ -8,6 +8,8 @@ import edu.hm.hafner.grading.CommentBuilder;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -23,14 +25,9 @@ abstract class GitLabCommentBuilder extends CommentBuilder {
     private final boolean hideWarningDescription;
     private final boolean skipCommitComments;
 
-    @VisibleForTesting
-    @SuppressWarnings("NullAway")
-    GitLabCommentBuilder() {
-        this(null, new FilteredLog("Errors"));
-    }
-
-    GitLabCommentBuilder(final CommitsApi commitsApi, final FilteredLog log, final String... prefixesToRemove) {
-        super(prefixesToRemove);
+    GitLabCommentBuilder(final CommitsApi commitsApi, final Map<String, Set<Integer>> modifiedFiles,
+            final FilteredLog log, final String... prefixesToRemove) {
+        super(modifiedFiles, prefixesToRemove);
 
         this.commitsApi = commitsApi;
         this.log = log;
@@ -62,7 +59,7 @@ abstract class GitLabCommentBuilder extends CommentBuilder {
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
-    protected String createMarkdownMessage(final CommentType commentType, final String relativePath,
+    static String createMarkdownMessage(final CommentType commentType, final String relativePath,
             final int lineStart, final int lineEnd, final int columnStart, final int columnEnd,
             final String title, final String message, final String details,
             final Function<String, String> environment) {
@@ -83,18 +80,7 @@ abstract class GitLabCommentBuilder extends CommentBuilder {
                 + (details.isBlank() ? StringUtils.EMPTY : "\n\n" + details);
     }
 
-    protected String createRange(final char prefix, final int start, final int end) {
-        if (start < 1) {
-            return StringUtils.EMPTY;
-        }
-        var single = String.valueOf(prefix) + start;
-        if (end <= start) {
-            return single;
-        }
-        return single + "-" + prefix + end;
-    }
-
-    private String getIcon(final CommentType commentType) {
+    static String getIcon(final CommentType commentType) {
         return switch (commentType) {
             case WARNING -> "warning";
             case NO_COVERAGE, PARTIAL_COVERAGE -> "footprints";
@@ -103,12 +89,23 @@ abstract class GitLabCommentBuilder extends CommentBuilder {
     }
 
     @VisibleForTesting
-    String createLinesAndColumns(final String range, final int columnStart, final int columnEnd) {
+    static String createLinesAndColumns(final String range, final int columnStart, final int columnEnd) {
         var columns = createRange('C', columnStart, columnEnd);
         if (columns.isBlank()) {
             return "(%s)".formatted(range);
         }
         return "(%s:%s)".formatted(range, columns);
+    }
+
+    static String createRange(final char prefix, final int start, final int end) {
+        if (start < 1) {
+            return StringUtils.EMPTY;
+        }
+        var single = String.valueOf(prefix) + start;
+        if (end <= start) {
+            return single;
+        }
+        return single + "-" + prefix + end;
     }
 
     protected FilteredLog getLog() {

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabCommitCommentBuilder.java
@@ -6,6 +6,9 @@ import org.gitlab4j.models.Constants.LineType;
 
 import edu.hm.hafner.util.FilteredLog;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Creates GitLab commit comments for static analysis warnings, for lines with missing coverage, and for lines with
  * survived mutations.
@@ -16,9 +19,9 @@ class GitLabCommitCommentBuilder extends GitLabCommentBuilder {
     private final long projectId;
     private final String sha;
 
-    GitLabCommitCommentBuilder(final CommitsApi commitsApi, final long projectId, final String sha,
-            final String workingDirectory, final FilteredLog log) {
-        super(commitsApi, log, workingDirectory);
+    GitLabCommitCommentBuilder(final CommitsApi commitsApi, final Map<String, Set<Integer>> modifiedFiles,
+            final long projectId, final String sha, final String workingDirectory, final FilteredLog log) {
+        super(commitsApi, modifiedFiles, log, workingDirectory);
 
         this.projectId = projectId;
         this.sha = sha;
@@ -26,7 +29,7 @@ class GitLabCommitCommentBuilder extends GitLabCommentBuilder {
 
     @Override
     @SuppressWarnings("checkstyle:ParameterNumber")
-    protected void createComment(final CommentType commentType, final String relativePath,
+    protected boolean createComment(final CommentType commentType, final String relativePath,
             final int lineStart, final int lineEnd,
             final String message, final String title,
             final int columnStart, final int columnEnd,
@@ -37,10 +40,13 @@ class GitLabCommitCommentBuilder extends GitLabCommentBuilder {
                         lineEnd, columnStart, columnEnd, title, message, markDownDetails, this::getEnv);
 
                 getCommitsApi().addComment(projectId, sha, markdownMessage, relativePath, adjustLine(lineStart), LineType.NEW);
+
+                return true;
             }
             catch (GitLabApiException exception) {
                 getLog().logException(exception, "Can't create commit comment for %s", relativePath);
             }
         }
+        return false;
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilder.java
@@ -9,6 +9,10 @@ import org.gitlab4j.api.models.Position;
 import org.gitlab4j.models.Constants.LineType;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Creates GitLab merge request comments for static analysis warnings, for lines with missing coverage, and for lines with
@@ -22,9 +26,10 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
     private final MergeRequestVersion lastVersion;
     private final boolean isLoggingEnabled;
 
-    GitLabDiffCommentBuilder(final CommitsApi commitsApi, final DiscussionsApi discussionsApi, final MergeRequest mergeRequest,
-            final MergeRequestVersion lastVersion, final String workingDirectory, final FilteredLog log) {
-        super(commitsApi, log, workingDirectory);
+    GitLabDiffCommentBuilder(final CommitsApi commitsApi, final Map<String, Set<Integer>> modifiedFiles, final DiscussionsApi discussionsApi,
+            final MergeRequest mergeRequest, final MergeRequestVersion lastVersion,
+            final String workingDirectory, final FilteredLog log) {
+        super(commitsApi, modifiedFiles, log, workingDirectory);
 
         this.discussionsApi = discussionsApi;
         this.mergeRequest = mergeRequest;
@@ -33,26 +38,38 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
     }
 
     @Override
-    @SuppressWarnings("checkstyle:ParameterNumber")
-    protected void createComment(final CommentType commentType, final String relativePath,
+    @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.NullAssignment"})
+    protected boolean createComment(final CommentType commentType, final String relativePath,
             final int lineStart, final int lineEnd,
             final String message, final String title,
             final int columnStart, final int columnEnd,
             final String details, final String markDownDetails) {
-        var sha = lastVersion.getHeadCommitSha();
-        var position = new Position()
+        @CheckForNull
+        Position position;
+        if (isPartOfChangedFiles(relativePath, lineStart, lineEnd)) {
+            position = new Position()
                 .withBaseSha(lastVersion.getBaseCommitSha())
-                .withHeadSha(sha)
+                .withHeadSha(lastVersion.getHeadCommitSha())
                 .withStartSha(lastVersion.getStartCommitSha())
                 .withNewPath(relativePath)
                 .withNewLine(adjustLine(lineStart))
                 .withPositionType(Position.PositionType.TEXT);
+        }
+        else {
+            if (commentType != CommentType.WARNING) {
+                return false; // do not create coverage comments for lines that are not part of the diff
+            }
+            // GitLab API requires a position for comments on merge requests, but if the file is not part of the diff,
+            // then we cannot create a position. In this case, we will create a comment on the commit instead.
+            position = null;
+        }
+
         var markdownMessage = createMarkdownMessage(commentType, relativePath, lineStart, lineEnd, columnStart,
                 columnEnd, title, message, markDownDetails, this::getEnv);
         try {
             if (isLoggingEnabled) {
                 getLog().logInfo("Creating merge request comment for %s in #%d", relativePath, mergeRequest.getIid());
-                getLog().logInfo("Position is %s", position);
+                logPosition(position);
                 getLog().logInfo("CommentType is %s", commentType);
                 getLog().logInfo("Message is %s", message);
                 getLog().logInfo("Full Message is %s", markdownMessage);
@@ -61,20 +78,35 @@ class GitLabDiffCommentBuilder extends GitLabCommentBuilder {
                     mergeRequest.getProjectId(),
                     mergeRequest.getIid(),
                     markdownMessage, null, null, position);
+
+            return true;
         }
         catch (GitLabApiException exception) { // If the comment is on a file or position not part of the diff
             getLog().logException(exception, "Can't create merge request comment for %s in #%d", relativePath, mergeRequest.getIid());
-            getLog().logError("Position is %s", position);
+            logPosition(position);
 
-            if (showCommentsInCommit()) {
+            if (showCommentsInCommit()) { // Fallback: create a comment on the commit if not possible for the MR
                 try {
-                    getCommitsApi().addComment(mergeRequest.getProjectId(), sha, markdownMessage, relativePath,
-                            lineStart, LineType.NEW);
+                    getCommitsApi().addComment(mergeRequest.getProjectId(), lastVersion.getStartCommitSha(),
+                            markdownMessage, relativePath, lineStart, LineType.NEW);
+
+                    return true;
                 }
                 catch (GitLabApiException _) {
                     getLog().logException(exception, "Can't create commit comment for %s", relativePath);
                 }
             }
+
+            return false;
+        }
+    }
+
+    private void logPosition(@CheckForNull final Position position) {
+        if (position == null) {
+            getLog().logInfo("Position is not set");
+        }
+        else {
+            getLog().logInfo("Position is %s", position);
         }
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabAutoGradingRunnerDockerITest.java
@@ -259,7 +259,7 @@ class GitLabAutoGradingRunnerDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.2.1"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/autograding-gitlab-action:5.3.0"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)

--- a/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/gitlab/GitLabDiffCommentBuilderTest.java
@@ -18,7 +18,7 @@ import edu.hm.hafner.grading.ToolConfiguration;
 import edu.hm.hafner.grading.ToolParser;
 import edu.hm.hafner.util.FilteredLog;
 
-import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static edu.hm.hafner.grading.gitlab.GitLabDiffCommentBuilder.*;
@@ -50,47 +50,40 @@ class GitLabDiffCommentBuilderTest {
             """;
     private static final String PROJECT_URL = "CI_PROJECT_URL";
     private static final String COMMIT_SHA = "CI_COMMIT_SHA";
-    private static final Optional<Path> NO_DELTA = Optional.empty();
 
     @Test
     void shouldCreateRange() {
-        var builder = spy(GitLabCommentBuilder.class);
+        assertThat(createRange('L', 0, 0)).isEmpty();
+        assertThat(createRange('L', -1, 10)).isEmpty();
 
-        assertThat(builder.createRange('L', 0, 0)).isEmpty();
-        assertThat(builder.createRange('L', -1, 10)).isEmpty();
-
-        assertThat(builder.createRange('L', 1, 10)).isEqualTo("L1-L10");
-        assertThat(builder.createRange('L', 1, 1)).isEqualTo("L1");
+        assertThat(createRange('L', 1, 10)).isEqualTo("L1-L10");
+        assertThat(createRange('L', 1, 1)).isEqualTo("L1");
     }
 
     @Test
     void shouldCreateLinesAndColumns() {
-        var builder = spy(GitLabCommentBuilder.class);
-
-        assertThat(builder.createLinesAndColumns("L1", 0, 0)).isEqualTo("(L1)");
-        assertThat(builder.createLinesAndColumns("L1", 1, 0)).isEqualTo("(L1:C1)");
-        assertThat(builder.createLinesAndColumns("L1", 2, 3)).isEqualTo("(L1:C2-C3)");
+        assertThat(createLinesAndColumns("L1", 0, 0)).isEqualTo("(L1)");
+        assertThat(createLinesAndColumns("L1", 1, 0)).isEqualTo("(L1:C1)");
+        assertThat(createLinesAndColumns("L1", 2, 3)).isEqualTo("(L1:C2-C3)");
     }
 
     @Test
     void shouldCreateMarkDownMessage() {
-        var builder = spy(GitLabCommentBuilder.class);
-
-        assertThat(builder.createMarkdownMessage(
+        assertThat(createMarkdownMessage(
                 CommentType.WARNING, FILE,
                 10, 20, 5, 8,
                 "Title", "Message", "Details", this::getEnv))
                 .contains("#### :warning: &nbsp; Title", "Message", "Details",
                         "[Assignment.java(L10-L20:C5-C8)]",
                         URL + "/blob/" + SHA + "/" + FILE + "#L10-L20");
-        assertThat(builder.createMarkdownMessage(
+        assertThat(createMarkdownMessage(
                 CommentType.WARNING, FILE,
                 10, 20, 0, 8,
                 "Title", "Message", "Details", this::getEnv))
                 .contains("#### :warning: &nbsp; Title", "Message", "Details",
                         "[Assignment.java(L10-L20)]",
                         URL + "/blob/" + SHA + "/" + FILE + "#L10-L20");
-        assertThat(builder.createMarkdownMessage(
+        assertThat(createMarkdownMessage(
                 CommentType.WARNING, FILE,
                 10, 10, 0, 8,
                 "Title", "Message", "Details", this::getEnv))
@@ -113,7 +106,7 @@ class GitLabDiffCommentBuilderTest {
     void shouldCreateComment() throws GitLabApiException {
         var discussions = mock(DiscussionsApi.class);
         var commits = mock(CommitsApi.class);
-        var builder = new GitLabDiffCommentBuilder(commits, discussions, mock(MergeRequest.class),
+        var builder = new GitLabDiffCommentBuilder(commits, Map.of(), discussions, mock(MergeRequest.class),
                 mock(MergeRequestVersion.class), "/work", new FilteredLog("GitLab"));
 
         builder.createComment(CommentType.WARNING, FILE_NAME, 10, 100,
@@ -134,11 +127,11 @@ class GitLabDiffCommentBuilderTest {
     void shouldCreateAnnotation() throws GitLabApiException {
         var discussions = mock(DiscussionsApi.class);
         var commits = mock(CommitsApi.class);
-        var gitlab = new GitLabDiffCommentBuilder(commits, discussions, mock(MergeRequest.class), mock(
+        var gitlab = new GitLabDiffCommentBuilder(commits, Map.of(), discussions, mock(MergeRequest.class), mock(
                         MergeRequestVersion.class), "/work", new FilteredLog("GitLab"));
 
         var score = new AggregatedScore(new FilteredLog("Tests"));
-        score.gradeAnalysis(new ReportGenerator(), AnalysisConfiguration.from(ANALYSIS_CONFIGURATION), NO_DELTA);
+        score.gradeAnalysis(new ReportGenerator(), AnalysisConfiguration.from(ANALYSIS_CONFIGURATION), Optional.empty());
 
         gitlab.createAnnotations(score);
 


### PR DESCRIPTION
GitLab cannot publish comments for files that are not part of the diff. So it makes sense to skip those comments.

Warnings are considered differently because some warnings are shown for dependencies or unrelated files. These warnings are added as MR comments without a source code reference.